### PR TITLE
Add a new endpoint for new question assignment events

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,4 +120,34 @@ controller.setupWebserver(appEnv.port, function(err, express_webserver) {
             res.send('This endpoint expects a specific data structure; see docs');
         }
     });
+
+    express_webserver.post('/stackoverflow/event', function(req, res) {
+        // other events can be handled, currently it is assuming type = "assigned"
+        if(typeof req.body.data !== 'undefined'
+            && typeof req.body.data.question_id !== 'undefined') {
+            let data = req.body.data;
+
+            let text = "This question _" + he.decode(data.title) + "_ has been assigned to <@" + data.assigned_to + ">. <https://sodashboard.mybluemix.net/home.html#edit?" + data.question_id + "| View on the dashboard>";
+
+            console.log(text);
+
+            var msg1 = {
+                color: "#99ccff",
+                text: text
+            };
+            var msg = {
+                type: "message",
+                channel: process.env.SLACK_CHANNEL_ID,
+                attachments: [ msg1 ]
+            };
+            bot.say(msg);
+
+            res.send('OK');
+
+        } else {
+            res.status(400);
+            res.send('This endpoint expects a specific data structure; see docs');
+        }
+
+    });
 });

--- a/app.js
+++ b/app.js
@@ -127,7 +127,7 @@ controller.setupWebserver(appEnv.port, function(err, express_webserver) {
             && typeof req.body.data.question_id !== 'undefined') {
             let data = req.body.data;
 
-            let text = "This question _" + he.decode(data.title) + "_ has been assigned to <@" + data.assigned_to + ">. <https://sodashboard.mybluemix.net/home.html#edit?" + data.question_id + "| View on the dashboard>";
+            let text = "The question _" + he.decode(data.title) + "_ has been assigned to <@" + data.assigned_to + ">. <https://sodashboard.mybluemix.net/home.html#edit?" + data.question_id + "| View on the dashboard>";
 
             console.log(text);
 


### PR DESCRIPTION
When a POST request comes to `/stackoverflow/event` with the correct data format, let that user know that they have a question assigned to them.  Tricky to test since the test systems do not have genuine user IDs attached, I have this working locally apart from the user naming part and would appreciate some code review - bonus points if you can also run this locally!

To test:

Try a POST request: `curl -X POST -H "Content-Type: application/json" [path to your bot URL, can be localhost]/stackoverflow/event -d @data.json` with the `data.json` something like:

```
{
    "type": "assigned",
    "data": {
        "assigned_to": "U4",
        "assigned_to_name": "susie",
        "assigned_by": "U5",
        "assigned_by_name": "sarah",
        "question_id": "49232701",
        "title": "Compare 2 dates in a symfony form with mapped = false"
    }
}
```

Alternatively, grab the cloud functions PR as well, and test by combining the two.